### PR TITLE
Refactor Drawable

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <input type="range" id="breite" min=60 max=150 value="95" title="Katapultbreite" />
         <input type="range" id="armLaenge" min=50 max=150 value="95" title="Armlänge" />
         <input type="range" id="achse" min=-20 max=20 value="4" title="Achsenposition" />
-        <input type="text" id="name" value="Mein Name" size="15">
+        <input type="text" id="name" value="Mein Name" size="15" title="Beschriftung Seitenteile (wenn verschiedene Beschriftungen gewünscht, diese mit Strichpunkt trennen)">
         <button id="download" title="SVG-Datei herunterladen">Download</button>
         <button id="qrcode" title="QR-Code anzeigen">QR-Code</button>
         <button id="scan" title="Mit Kamera QR-Code scannen" style="display:none">Scanner</button>        

--- a/js/catapult.js
+++ b/js/catapult.js
@@ -3,7 +3,13 @@
 // Imports
 import * as sb from './svgbuilder.js'
 import { makeQRCode, canScan, scan } from './qrhandling.js'
-import { requireLandscape, getParamString, setParamsFromString, makeBookmarkable, download } from './ui.js'
+import {
+    requireLandscape,
+    getParamString,
+    setParamsFromString,
+    makeBookmarkable,
+    download
+} from './ui.js'
 
 const svg = document.querySelector("svg")
 const units = 'mm'
@@ -122,11 +128,11 @@ class Arm extends sb.Drawable {
         this.makeProp('aw', armWidth)
         this.makeProp('ro', armWidth) // Bucket outer radius
         this.makeProp('ri', armWidth / 2) // Bucket inner radius                
-        this.createRootElem('g', {
-            id: this.id
-        })
-        this.outline = this.createElem('path', cutProps)
-        this.elem.appendChild(this.outline)
+//        this.createRootElem('g', {
+//            id: this.id
+//        })
+        this.outline = this.createRootElem('path', cutProps)
+//        this.elem.appendChild(this.outline)
         this.bucket = this.createElem('circle', {
             cx: this.x,
             cy: this.y + this.ro,
@@ -250,17 +256,32 @@ class Side extends sb.Drawable {
         outline = outline.add(makeHole(this.ao + that.bh / 2 + 5))
 
         this.outline.setAttribute('d', outline)
+//        sb.resetTransform(this.elem)  // both variants are possible for this.elem
+        this.resetTransform()
         sb.resetTransform(this.outline)
-        sb.resetTransform(this.elem)
 
         this.textElem.innerHTML = this.text
         let textX = this.x + lPart * 2.5
 
         if (this.flip) {
             textX = this.x + lPart * 4.5
-            sb.mirrorX(this.outline, this.x + this.l / 2, this.y, true)
-            sb.rotate(this.elem, 180, this.x + this.l / 2, this.y, true)
-            sb.translate(this.elem, lPart * 2, -this.h - this.bh, true)
+            sb.mirrorX(this.outline, this.x + this.l / 2, this.y, false)
+//            sb.rotate(this.elem, 180, this.x + this.l / 2, this.y, false)
+//            sb.translate(this.elem, lPart * 2, -this.h - this.bh, false)
+            this.rotate(180, this.x + this.l / 2, this.y)
+            this.translate(lPart * 2, -this.h - this.bh)
+            if (this.text.includes(';')) {  // for fun: different strings per side
+                const [t1, t2] = this.text.split(';')
+                this.text = t2
+                this.update()
+                const other = sb.Drawable.all.filter(e => {
+                    return e instanceof Side && e.id != this.id
+                })
+                if (other.length === 1) {
+                    other[0].text = t1
+                    other[0].update()
+                }
+            }
         }
 
         sb.setAttribs(this.textElem, {
@@ -276,9 +297,9 @@ class Pins extends sb.Drawable {
         this.makeProp('x', x)
         this.makeProp('y', y)
         this.makeProp('l', length)
-        this.createRootElem('g', {})
-        this.path = this.createElem('path', cutProps)
-        this.elem.appendChild(this.path)
+//        this.createRootElem('g', {})
+        this.path = this.createRootElem('path', cutProps)
+//        this.elem.appendChild(this.path)
         this.makeTooltip('Keile zum Zusammenstecken')
     }
 
@@ -302,7 +323,7 @@ class Pins extends sb.Drawable {
 }
 
 function init() {
-    // Init is called automatically when page is loaded
+    // Init is called when page is completely loaded
 
     function updateThickness(evt) {
         thickness = Number(evt.target.value)
@@ -392,6 +413,21 @@ function init() {
 
     makeBookmarkable(allInputElems)
     requireLandscape(document.querySelector('#portraitMessage'))
+    
+    /*
+    Some tests for PathD construction from (almost) arbitrary objects:
+    // should succeed
+    console.log(new sb.PathD(arm))
+    console.log(new sb.PathD(new sb.PathD(239, 289)))
+    console.log(new sb.PathD(barNotch.elem.firstChild))
+    console.log(new sb.PathD("path"))  // DOM query selector
+    console.log(new sb.PathD("M 29 29"))
+    console.log(new sb.PathD(new paper.Path()))
+    // should fail
+//    console.log(new sb.PathD("]{}"))
+//    console.log(new sb.PathD(42))
+//    console.log(new sb.PathD(document.querySelector('input')))
+*/
 }
     
 window.addEventListener('load', init)

--- a/js/qrhandling.js
+++ b/js/qrhandling.js
@@ -2,7 +2,7 @@
 
 // import dependencies
 import loadScript from './jsloader.js'
-loadScript('./js/lib/QRCode.js')  // Adds 'QRCode' to global namespace
+loadScript('./js/lib/qrcode.js')  // Adds 'QRCode' to global namespace
 import QrScanner from './lib/qr-scanner.min.js'
 
 

--- a/js/svgbuilder.js
+++ b/js/svgbuilder.js
@@ -385,6 +385,33 @@ export class Drawable {
         callback()
     }
 
+    // Join and keep outline of both paths, discard inner overlap
+    union(a, b = undefined) {
+        if (!b) { b = a; a = this }
+        return PathD(a).boolean(PathD(b), 'unite')
+    }
+    // Subtract other path from this path
+    difference(a, b = undefined) {
+        if (!b) { b = a; a = this }
+        // Reversed for more intuitive "a - b":
+        return PathD(b).boolean(PathD(a), 'subtract')
+    }
+    // Only keep path around intersecting area
+    intersection(a, b = undefined) {
+        if (!b) { b = a; a = this }
+        return PathD(a).boolean(PathD(b), 'intersect')
+    }
+    // Only keep path *other* than intersecting area
+    exclude(a, b = undefined) {
+        if (!b) { b = a; a = this }
+        return PathD(a).boolean(PathD(b), 'exclude')
+    }
+    // Only keep part of this that is enclosed by other
+    divide(a, b = undefined) {
+        if (!b) { b = a; a = this }
+        return PathD(a).boolean(PathD(b), 'divide')
+    }
+
     toString() {
         return `[${this.constructor.name} ${this.id}]`
     }

--- a/js/svgbuilder.js
+++ b/js/svgbuilder.js
@@ -2,11 +2,20 @@
 
 // Import dependencies
 import loadScript from './jsloader.js'
-loadScript('./js/lib/paper-full.min.js')  // Adds 'paper' to global namespace
+loadScript('./js/lib/paper-full.min.js') // Adds 'paper' to global namespace
 
+
+function _isStr(something) {
+    return (typeof something === 'string' || something instanceof String)
+}
+
+function _isValidSVGPath(dStr) {
+    const regex = /^[\s\r\n]*[Mm]\s*((\s*(-?\d+(\.\d+)?\s*,?\s*){2})|(\s*(-?\d+(\.\d+)?)\s*)){1}((\s*[Ll]\s*(-?\d+(\.\d+)?\s*,?\s*){2}\s*)|(\s*[Hh]\s*(-?\d+(\.\d+)?\s*)\s*)|(\s*[Vv]\s*(-?\d+(\.\d+)?\s*)\s*)|(\s*[Cc]\s*(-?\d+(\.\d+)?\s*,?\s*){6}\s*)|(\s*[Ss]\s*(-?\d+(\.\d+)?\s*,?\s*){4}\s*)|(\s*[Qq]\s*(-?\d+(\.\d+)?\s*,?\s*){4}\s*)|(\s*[Tt]\s*(-?\d+(\.\d+)?\s*,?\s*){2}\s*)|(\s*[Aa]\s*(-?\d+(\.\d+)?\s*,?\s*){7}\s*)|(\s*[Zz]\s*)?)*[\s\r\n]*$/
+    return regex.test(dStr);
+}
 
 export function ensureObj(queryOrObject) {
-    if (typeof queryOrObject === 'string' || queryOrObject instanceof String) {
+    if (_isStr(queryOrObject)) {
         queryOrObject = document.querySelector(queryOrObject)
     }
     return queryOrObject
@@ -30,57 +39,60 @@ export function appendTransform(svgObj, transformStr) {
     return svgObj
 }
 
-export function scale(svgObj, scaleX, scaleY, centerX = 0, centerY = 0, inplace = false) {
+export function scale(svgObj, scaleX, scaleY, centerX = 0, centerY = 0, makeCopy = true) {
     // For mirroring, use a scale factor of -1
     svgObj = ensureObj(svgObj)
-    if (!inplace) {
+    if (makeCopy) {
         svgObj = svgObj.cloneNode()
     }
     appendTransform(svgObj, `translate(${centerX}, ${centerY}) scale(${scaleX}, ${scaleY}) translate(${-centerX}, ${-centerY})`)
     return svgObj
 }
 
-export function rotate(svgObj, angle, centerX = 0, centerY = 0, inplace = false) {
+export function rotate(svgObj, angle, centerX = 0, centerY = 0, makeCopy = true) {
     svgObj = ensureObj(svgObj)
-    if (!inplace) {
+    if (makeCopy) {
         svgObj = svgObj.cloneNode()
     }
     appendTransform(svgObj, `translate(${centerX}, ${centerY}) rotate(${angle}) translate(${-centerX}, ${-centerY})`)
     return svgObj
 }
 
-export function skew(svgObj, skewX, skewY = 0, inplace = false) {
+export function skew(svgObj, skewX, skewY = 0, makeCopy = true) {
     svgObj = ensureObj(svgObj)
-    if (!inplace) {
+    if (makeCopy) {
         svgObj = svgObj.cloneNode()
     }
     appendTransform(svgObj, `skew(${skewX}, ${skewY})`)
     return svgObj
 }
 
-export function translate(svgObj, dx, dy, inplace = false) {
+export function translate(svgObj, dx, dy, makeCopy = true) {
     svgObj = ensureObj(svgObj)
-    if (!inplace) {
+    if (makeCopy) {
         svgObj = svgObj.cloneNode()
     }
     appendTransform(svgObj, `translate(${dx}, ${dy})`)
     return svgObj
 }
 
-export function mirrorX(svgObj, centerX = 0, centerY = 0, inplace = false) {
-    return scale(svgObj, -1, 1, centerX, centerY, inplace)
+export function mirrorX(svgObj, centerX = 0, centerY = 0, makeCopy = true) {
+    return scale(svgObj, -1, 1, centerX, centerY, makeCopy)
 }
 
-export function mirrorY(svgObj, centerX = 0, centerY = 0, inplace = false) {
-    return scale(svgObj, 1, -1, centerX, centerY, inplace)
+export function mirrorY(svgObj, centerX = 0, centerY = 0, makeCopy = true) {
+    return scale(svgObj, 1, -1, centerX, centerY, makeCopy)
 }
 
 export class PathD {
     // https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
-    constructor(startAtX, startAtY) {
+    constructor(startAtX_or_ObjToConstructFrom, startAtY) {
         this.d = ''
-        if (startAtX !== undefined && startAtY !== undefined) {
-            this.absMove(startAtX, startAtY)
+        if (startAtX_or_ObjToConstructFrom !== undefined && startAtY !== undefined) {
+            this.absMove(startAtX_or_ObjToConstructFrom, startAtY)
+        }
+        else if (startAtX_or_ObjToConstructFrom !== undefined && startAtY == undefined) {
+            this.d = PathD.getDStrFromAny(startAtX_or_ObjToConstructFrom)
         }
     }
 
@@ -154,26 +166,26 @@ export class PathD {
 
     // Join and keep outline of both paths, discard inner overlap
     union(other) {
-            return this.boolean(other, 'unite')
-        }
-        // Subtract other path from this path
+        return this.boolean(other, 'unite')
+    }
+    // Subtract other path from this path
     difference(other) {
-            return other.boolean(this, 'subtract')
-        }
-        // Only keep path around intersecting area
+        return other.boolean(this, 'subtract')
+    }
+    // Only keep path around intersecting area
     intersection(other) {
-            return this.boolean(other, 'intersect')
-        }
-        // Only keep path *other* than intersecting area
+        return this.boolean(other, 'intersect')
+    }
+    // Only keep path *other* than intersecting area
     exclude(other) {
-            return this.boolean(other, 'exclude')
-        }
-        // Only keep part of this that is enclosed by other
+        return this.boolean(other, 'exclude')
+    }
+    // Only keep part of this that is enclosed by other
     divide(other) {
         return this.boolean(other, 'divide')
     }
-
-    static fromSvg(svgObj) {
+    
+    static getDStrFromSvg(svgObj) {
         PathD._ensurePaperReady()
         svgObj = ensureObj(svgObj)
         paper.project.clear()
@@ -181,32 +193,24 @@ export class PathD {
             expandShapes: true, // expand everything to path items
             insert: true, // draw the path
         })
-        const paths = []
+        const dStrings = []
         for (const item of paper.project.activeLayer.children) {
             let d = ''
-            if (item instanceof paper.Path) {
+            if (item instanceof paper.Path || item instanceof paper.CompoundPath) {
                 d = item.exportSVG().getAttribute('d')
             } else {
-                throw Error(`PathD.fromSvg got passed a ${typeof item}: ${item}. Only shapes (paths, circles, rects, ...) are allowed`)
+                throw Error(`PathD.fromSvg got passed a(n) ${typeof item}: ${item}. Only shapes (paths, circles, rects, ...) are allowed`)
             }
-            paths.push(PathD.fromString(d))
-            if (paths.length > 1) {
+            dStrings.push(d)
+            if (dStrings.length > 1) {
                 console.warn(`PathD.fromSvg got more than one object. All but the first object will be ignored`)
             }
         }
-        return paths[0]
-            //                const name = svgObj.tagName.toLowerCase()
-            //                if (name === 'circle') {
-            //                    const x = Number(svgObj.getAttribute('cx'))
-            //                    const y = Number(svgObj.getAttribute('cy'))
-            //                    const r = Number(svgObj.getAttribute('r'))
-            //                    const obj = paper.Shape.Circle(
-            //                        new paper.Point(x, y),
-            //                        r
-            //                    )
-            //                    const path = obj.toPath(false).exportSVG()
-            //                    return PathD.fromString(path.getAttribute('d'))
-            //                }
+        return dStrings[0]
+}
+
+    static fromSvg(svgObj) {
+        return PathD.fromString(PathD.getDStrFromSvg(svgObj))
     }
 
     static fromString(dStr) {
@@ -214,9 +218,64 @@ export class PathD {
         p.d = dStr
         return p
     }
+    
+    static getDStrFromAny(something) {
+        // Already a PathD?
+        if (something instanceof PathD) {
+            console.debug(`PathD.getDStrFromAny() got a PathD (${something})`)
+            return something.d
+        }
+        // paper.js Path object?
+        if (something instanceof paper.Path) {
+            console.debug(`PathD.getDStrFromAny() got a paper.Path (${something})`)
+            return something.exportSVG().getAttribute('d')
+        }
+        // SVG path?
+        if (something.tagName === 'path' && something.hasAttribute('d')) {
+            console.debug(`PathD.getDStrFromAny() got an SVG path (${something})`)
+            return something.getAttribute('d')
+        }
+        // Drawable? Try its root element
+        if (something instanceof Drawable) {
+            console.debug(`PathD.getDStrFromAny() got a Drawable (${something})`)
+            return PathD.getDStrFromSvg(something.elem)
+        }
+        // Other SVG object?
+        try {
+            const d = PathD.getDStrFromSvg(something)
+            console.debug(`PathD.getDStrFromAny() got an SVG object (${something})`)
+            return d
+        }
+        catch (e) {
+            if (e instanceof DOMException) {
+                // Not an SVG element
+                // try whether something is a valid d string
+                if (_isValidSVGPath(something)) {                  
+                    console.debug(`PathD.getDStrFromAny() got a d string (${something})`)
+                    return something
+                }
+                else {
+                    throw Error(`PathD.fromAny() could not interpret object: ${something}.`)
+                }
+            }
+            else {
+                // Something else went wrong
+                throw e
+            }
+        }    }
+    
+    static fromAny(something) {
+        return PathD.fromString(PathD.getDStrFromAny(something))
+    }
 
     toString() {
         return this.d.trim()
+    }
+    
+    toElem() {
+        const elem = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+        elem.setAttribute('d', this.d)
+        return elem
     }
 }
 
@@ -330,6 +389,22 @@ export class Drawable {
         return `[${this.constructor.name} ${this.id}]`
     }
 }
+// Make a couple helper functions also methods of Drawable.
+// No, I don't like this solution either, but I don't like repeating myself more.
+for (const method of[setAttribs, resetTransform, appendTransform, scale, rotate, skew, translate, mirrorX, mirrorY]) {
+    Drawable.prototype[method.name] = function (...args) {
+        // forcing makeCopy=false for method
+        if (args.length > 0 && typeof args[args.length-1] === 'boolean') {
+            console.log(args[args.length-1])
+            args[args.length-1] = false
+        }
+        else {
+            args.push(false)
+        }
+        return method(this.elem, ...args)
+    }
+}
+
 
 export class Group extends Drawable {
     constructor(drawablesToContain, attribs, parent = undefined) {
@@ -391,6 +466,7 @@ export class SvgProxy extends Drawable {
     }
 }
 
+// Export SVG markup string (units in mm)
 export function getSvgString(svgElem) {
     PathD._ensurePaperReady()
     paper.project.activeLayer.importSVG(svgElem, {


### PR DESCRIPTION
closes #4

Until now, we got three kinds of separate sources for drawing-related functionality:
 - Drawable base class members themselves (such as createElement)
 - PathD object stuff for path creation and for boolean operations
 - standalone helper functions for transformation (translate, scale, etc.)
 - SVG DOM operations (remember that our goal is not to simply re-create or wrap existing functionality)

This means that right now, the user, when implementing their Drawable, has to know where to find the functionality they are looking for. We won't be able to get rid of the Drawable vs DOM distinction, but we can reduce the rest.

 - Make transformation helpers members of Drawable (also keeping them available separately for flexibility, but at least the "happy flow" of simple one-object Drawables can be done within Drawable and does not require the user to hunt down helper functions). They are manipulating `this.elem` in-place (the standalone helpers return a copy by default).
 - Put boolean operations into Drawable (making the PathD creation transparent/automatic when using booleans)
 - PathD will stay separate (we cannot tie it into a fixed sub-object of Drawable without enforcing a rigid structure of how the user has to draw their shapes)

Open questions:
 - Boolean operations return a path by necessity (cannot be any other shape). Currently, the user is responsible for assigning the returned PathD object to an SVG Path's `d` attribute. They can also use `mypathd.toElem()` to create an SVG Path object from it. But there is no automatic assignment back to the Drawable's object tree (`this.elem` or lower). We don't know what the user's intention is (replacing an object by the boolean's result or creating a new object). For safety, I'm tending to always creating a new object. But should we automatically return new SVG Path object instead of PathD objects maybe? This might make those methods easier to use for the user.
 - What about PathD vs SVG Path's for path creation? Maybe we should add a Drawable method "createPath" which just makes a Path. But then, should it be a PathD (where lineTo etc. can be used) or an SVG Path? We *could* hack the SVG object's prototype with a PathD and add those methods to it, but I really don't like that at all.