### PR TITLE
Fix orientation check on iOS

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -5,11 +5,17 @@
 
 function portraitCheck(elem) {
     window.setTimeout(_ => {
-        if (screen.orientation.type.includes('portrait')) {
-            elem.style.display = "block"
-        } else {
-            elem.style.display = "none"
+        let display = "none"
+        if (screen.orientation && screen.orientation.type) {
+            // Separate if statement because on desktop matchMedia gives false positives
+            if (screen.orientation.type.includes('portrait')) {
+                display = "block"
+            }
         }
+        else if (window.matchMedia("(orientation: portrait)").matches) {
+            display = "block"
+         }
+        elem.style.display = display
     }, 200)
 }
 


### PR DESCRIPTION
screen.orientation.type is not yet available on iOS

window.matchMedia gives false positives on desktop (tested with Chrome)

checking for presence of screen.orientation, and if available, using it. If not available, use window.matchMedia