### PR TITLE
Add parameter versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,10 @@ jobs:
         
 #      - name: Install SSH client
 #        run: sudo apt-get update && sudo apt-get install -y openssh-client
-        
+
+      - name: What have we here?
+        run: ls -la
+
       - name: Set up SSH key
         run: |
           mkdir -p ~/.ssh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ run-name: Deploy after PR merge by ${{ github.actor }}
 on: 
     push:
         branches: [ main ]
-    pull_request:
-        branches: [ main ]
+#    pull_request:
+#        branches: [ main ]
 
 jobs:
   upload_site:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: deploy
+run-name: Deploy after PR merge by ${{ github.actor }}
+on: 
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+jobs:
+  upload_site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+#      - name: Install SSH client
+#        run: sudo apt-get update && sudo apt-get install -y openssh-client
+        
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -t rsa ${{ secrets.SFTP_SERVER }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to SFTP
+        run: |
+          echo "Uploading files to SFTP server..."
+          sftp -b - ${{ secrets.SFTP_USERNAME }}@${{ secrets.SFTP_SERVER }} <<EOF
+          put -r svgbuilder/* /
+          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,6 @@ jobs:
 #      - name: Install SSH client
 #        run: sudo apt-get update && sudo apt-get install -y openssh-client
 
-      - name: What have we here?
-        run: ls -la
-
       - name: Set up SSH key
         run: |
           mkdir -p ~/.ssh
@@ -30,5 +27,5 @@ jobs:
         run: |
           echo "Uploading files to SFTP server..."
           sftp -b - ${{ secrets.SFTP_USERNAME }}@${{ secrets.SFTP_SERVER }} <<EOF
-          put -r svgbuilder/* /
+          put -r * /
           EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
+.idea
+
 

--- a/catapult_v1.html
+++ b/catapult_v1.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Katapult</title>
+    <meta charset="utf-8">
+    <script type="module" src="js/catapult.js"></script>
+    <link rel="stylesheet" href="css/svgbuilder.css">
+    <link rel="stylesheet" href="css/catapult.css">
+</head>
+
+<body>
+    <h2>Katapult konfigurieren</h2>
+    <div id="portraitMessage">Bitte Telefon auf die Seite drehen.</div>
+    <p id="controls">
+        <label><input type="number" id="dicke" min="2" max="4" value="3.8" style="width:3em" title="Materialstärke">mm</label>
+        <input type="range" id="laenge" min=150 max=300 value="210" title="Katapultlänge" />
+        <input type="range" id="breite" min=60 max=150 value="95" title="Katapultbreite" />
+        <input type="range" id="armLaenge" min=50 max=150 value="95" title="Armlänge" />
+        <input type="range" id="achse" min=-20 max=20 value="4" title="Achsenposition" />
+        <input type="text" id="name" value="Mein Name" size="15" title="Beschriftung Seitenteile (wenn verschiedene Beschriftungen gewünscht, diese mit Strichpunkt trennen)">
+        <button id="download" title="SVG-Datei herunterladen">Download</button>
+        <button id="qrcode" title="QR-Code anzeigen">QR-Code</button>
+        <button id="scan" title="Mit Kamera QR-Code scannen" style="display:none">Scanner</button>        
+    </p>
+    <svg viewbox="0 0 450 350">
+
+        <!-- put static objects here -->
+        
+    </svg>
+    <div class="footer">
+        License of design <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">Creative Commons - Attribution - Non-Commercial</a>. License of source code: MIT License (2023 by Andreas Schuderer).
+        Design based on this educational <a href="https://www.thingiverse.com/thing:1403796" target="_blank">Tension Catapult by Thingiverse user mfalk</a> (<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>) and its <a href="https://www.thingiverse.com/thing:4050155" target="_blank">no-glue derivative by SimpleAsWar</a> (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>).
+    </div>
+    <div id="overlay"></div>
+    <video id="video"></video>
+</body>
+
+</html>

--- a/catapult_v2.html
+++ b/catapult_v2.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Katapult</title>
+    <meta charset="utf-8">
+    <script type="module" src="js/catapult.js"></script>
+    <link rel="stylesheet" href="css/svgbuilder.css">
+    <link rel="stylesheet" href="css/catapult.css">
+</head>
+
+<body>
+    <h2>Katapult konfigurieren</h2>
+    <div id="portraitMessage">Bitte Telefon auf die Seite drehen.</div>
+    <p id="controls">
+        <label><input type="number" id="dicke" min="2" max="4" value="3.8" style="width:3em" title="Materialstärke">mm</label>
+        <input type="range" id="laenge" min=150 max=300 value="210" title="Katapultlänge" />
+        <input type="range" id="breite" min=60 max=150 value="95" title="Katapultbreite" />
+        <input type="range" id="armLaenge" min=50 max=150 value="95" title="Armlänge" />
+        <input type="range" id="achse" min=-20 max=20 value="4" title="Achsenposition" />
+        <input type="text" id="name" value="Mein Name" size="15" title="Beschriftung Seitenteile (wenn verschiedene Beschriftungen gewünscht, diese mit Strichpunkt trennen)">
+        <button id="download" title="SVG-Datei herunterladen">Download</button>
+        <button id="qrcode" title="QR-Code anzeigen">QR-Code</button>
+        <button id="scan" title="Mit Kamera QR-Code scannen" style="display:none">Scanner</button>        
+    </p>
+    <svg viewbox="0 0 450 350">
+
+        <!-- put static objects here -->
+        
+    </svg>
+    <div class="footer">
+        License of design <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">Creative Commons - Attribution - Non-Commercial</a>. License of source code: MIT License (2023 by Andreas Schuderer).
+        Design based on this educational <a href="https://www.thingiverse.com/thing:1403796" target="_blank">Tension Catapult by Thingiverse user mfalk</a> (<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>) and its <a href="https://www.thingiverse.com/thing:4050155" target="_blank">no-glue derivative by SimpleAsWar</a> (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>).
+    </div>
+    <div id="overlay"></div>
+    <video id="video"></video>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -2,38 +2,15 @@
 <html>
 
 <head>
-    <title>Katapult</title>
+    <title>SVG Builder</title>
     <meta charset="utf-8">
-    <script type="module" src="js/catapult.js"></script>
-    <link rel="stylesheet" href="css/svgbuilder.css">
-    <link rel="stylesheet" href="css/catapult.css">
 </head>
 
 <body>
-    <h2>Katapult konfigurieren</h2>
-    <div id="portraitMessage">Bitte Telefon auf die Seite drehen.</div>
-    <p id="controls">
-        <label><input type="number" id="dicke" min="2" max="4" value="3.8" style="width:3em" title="Materialstärke">mm</label>
-        <input type="range" id="laenge" min=150 max=300 value="210" title="Katapultlänge" />
-        <input type="range" id="breite" min=60 max=150 value="95" title="Katapultbreite" />
-        <input type="range" id="armLaenge" min=50 max=150 value="95" title="Armlänge" />
-        <input type="range" id="achse" min=-20 max=20 value="4" title="Achsenposition" />
-        <input type="text" id="name" value="Mein Name" size="15" title="Beschriftung Seitenteile (wenn verschiedene Beschriftungen gewünscht, diese mit Strichpunkt trennen)">
-        <button id="download" title="SVG-Datei herunterladen">Download</button>
-        <button id="qrcode" title="QR-Code anzeigen">QR-Code</button>
-        <button id="scan" title="Mit Kamera QR-Code scannen" style="display:none">Scanner</button>        
-    </p>
-    <svg viewbox="0 0 450 350">
-
-        <!-- put static objects here -->
-        
-    </svg>
-    <div class="footer">
-        License of design <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">Creative Commons - Attribution - Non-Commercial</a>. License of source code: MIT License (2023 by Andreas Schuderer).
-        Design based on this educational <a href="https://www.thingiverse.com/thing:1403796" target="_blank">Tension Catapult by Thingiverse user mfalk</a> (<a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>) and its <a href="https://www.thingiverse.com/thing:4050155" target="_blank">no-glue derivative by SimpleAsWar</a> (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>).
-    </div>
-    <div id="overlay"></div>
-    <video id="video"></video>
+    <h2>Designs</h2>
+    <ul>
+        <li><a href="catapult_v1.html">Katapult</a></li>
+        <li><a href="catapult_v2.html">Katapult 2 (zum Testen)</a></li>
+    </ul>
 </body>
-
 </html>

--- a/js/qrhandling.js
+++ b/js/qrhandling.js
@@ -75,7 +75,7 @@ export function scan(videoElem, dataCallback) {
                 returnDetailedScanResult: true,
                 onDecodeError: err => {
                     if (_stopping) return
-                    console.log(`Error: ${err}`)
+                    console.log(err)
                     // Unnecessary (there are errors all the time)
 //                    if (!_qrScanner.$overlay._timeout) {
 //                        const scanOverlay =_qrScanner.$overlay.firstChild

--- a/js/ui.js
+++ b/js/ui.js
@@ -36,6 +36,22 @@ function getVersion() {
     return window.location.pathname.split('/').pop()
 }
 
+function openVersion(name) {
+    const curr = window.location.pathname.split('/')
+    curr.pop()  // remove file name
+    curr.push(name)
+    window.location.pathname = curr.join('/')
+}
+
+function checkVersion(requested) {
+    const current = getVersion()
+    if (requested !== current) {
+        console.error(`Version mismatch: requested version '${requested}' does not match current version '${current}'`)
+        const shouldSwitch = confirm(`Your settings are for '${requested}', but you are on '${current}'.\n\nSwitch to '${requested}?`)
+        if (shouldSwitch) openVersion(requested)
+    }
+}
+
 export function getParamString(inputElems=_knownInputElems) {
     let data = getVersion() + '~'
     for (const input of inputElems) {
@@ -47,11 +63,16 @@ export function getParamString(inputElems=_knownInputElems) {
 
 export function setParamsFromString(paramStr, inputElems=_knownInputElems) {
     const params = paramStr.split("~")
-    const requestedVersion = params.shift()
-    const currentVersion = getVersion()
-    if (requestedVersion !== currentVersion) {
-        throw new Error(`Version mismatch: requested ${requestedVersion} does not match current ${currentVersion}`)
+    const gotLegacyParams = isFinite(params[0])  // first param of catapult_v1.html is material thickness
+    let requestedVersion
+    if (gotLegacyParams) {
+        console.warn('got legacy params (without version) for catapult_v1')
+        requestedVersion = 'catapult_v1.html'
     }
+    else {
+        requestedVersion = params.shift()
+    }
+    checkVersion(requestedVersion)
     if (params.length !== inputElems.length) {
         throw new Error(`Version mismatch: ${inputElems.length} controls vs. ${params.length} params`)
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -31,8 +31,13 @@ export function requireLandscape(elem) {
 // Optionally registered input elements
 let _knownInputElems = []
 
+
+function getVersion() {
+    return window.location.pathname.split('/').pop()
+}
+
 export function getParamString(inputElems=_knownInputElems) {
-    let data = ''
+    let data = getVersion() + '~'
     for (const input of inputElems) {
         const val = input.value.replace('~', '-')
         data += `${encodeURIComponent(val)}~`
@@ -42,8 +47,13 @@ export function getParamString(inputElems=_knownInputElems) {
 
 export function setParamsFromString(paramStr, inputElems=_knownInputElems) {
     const params = paramStr.split("~")
+    const requestedVersion = params.shift()
+    const currentVersion = getVersion()
+    if (requestedVersion !== currentVersion) {
+        throw new Error(`Version mismatch: requested ${requestedVersion} does not match current ${currentVersion}`)
+    }
     if (params.length !== inputElems.length) {
-        console.error(`Version mismatch: ${inputElems.length} controls vs. ${params.length} params`)
+        throw new Error(`Version mismatch: ${inputElems.length} controls vs. ${params.length} params`)
     }
     console.debug(`Setting parameters from string ${paramStr}`)
     let i = 0


### PR DESCRIPTION
closes #12 

- Add a prefix with the design name and version to the parameters.
- In the current implementation, the convention is to use the current last path element (e.g. catapult_v2.html)
- If there's a mismatch, asks for confirmation to switch to the correct design (this should make the workshop setting easier if the participants are playing with more than one design at the same time). If one answers No, we still try to interpret the parameters (no guarantees though)
- This (including the confirmation dialog) works for both anchor/hash and qr code creation/scanning